### PR TITLE
Replace default region as "US East" was dropped from packaged configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY etc /etc
 
 RUN find /app -name "run" -exec chmod u+x {} \;
 
-ENV REGION="US East" \
+ENV REGION="Switzerland" \
     USERNAME="" \
     PASSWORD="" \
     UID="" \

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker-compose up -d
 
 ### Environment Variables
 
-`REGION` is optional. The default region is set to `US East`. `REGION` should match the supported PIA `.opvn` region config.
+`REGION` is optional. The default region is set to `Switzerland`. `REGION` should match the supported PIA `.opvn` region config.
 
 See the [PIA VPN Tunnel Network page](https://www.privateinternetaccess.com/pages/network/dkrpia) for details.
 Use the `Location` value for your `REGION`.

--- a/docker-compose-dist.yml
+++ b/docker-compose-dist.yml
@@ -13,7 +13,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - </path/on/host>:/config
     environment:
-      - REGION=US East
+      - REGION=Switzerland
       - USERNAME=<username>
       - PASSWORD=<password>
       - UID=<uid>


### PR DESCRIPTION
`US East.ovpn` is no longer available in the pre-packaged `ovpn` configs from PIA. Default region is now set to `Switzerland`.