### PR TITLE
Add MASQUERADE iptables option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.14
+FROM alpine:3.15
 
-RUN apk --no-cache add ca-certificates=~20191127 \
+RUN apk --no-cache add ca-certificates=~20211220 \
     && apk --no-cache add privoxy=~3.0 \
     && apk --no-cache add openvpn=~2.5 \
     && apk --no-cache add runit=~2.1 \

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Use the `Location` value for your `REGION`.
 
 `UID` / `GID` - Your UID/GID on your host machine.
 
+`MASQUERADE` - set to "true" to add masquerade rule for tun0 and use container as a router
+
 ## Connecting to the VPN Proxy
 
 To connect to the VPN Proxy, set your browser proxy to 127.0.0.1:8118 (or 0.0.0.0:8118 if that does not work). If you override the docker port `-p`, make sure to use that port number instead.

--- a/app/ovpn/run
+++ b/app/ovpn/run
@@ -42,7 +42,8 @@ else
 fi
 
 # Add masquerade to use the container as a virtual router
-[[ "$MASQUERADE" == "true" ]] && /sbin/iptables -t nat -A POSTROUTING -o tun0 -j MASQUERADE
+setup_iptables_rule=${MASQUERADE:-}
+[[ "$setup_iptables_rule" == "true" ]] && /sbin/iptables -t nat -A POSTROUTING -o tun0 -j MASQUERADE
 
 set -- "$@" '--data-ciphers' 'aes-256-cbc'
 

--- a/app/ovpn/run
+++ b/app/ovpn/run
@@ -41,6 +41,9 @@ else
   exit 1
 fi
 
+# Add masquerade to use the container as a virtual router
+[[ "$MASQUERADE" == "true" ]] && /sbin/iptables -t nat -A POSTROUTING -o tun0 -j MASQUERADE
+
 set -- "$@" '--data-ciphers' 'aes-256-cbc'
 
 openvpn "$@"


### PR DESCRIPTION
- Updated Alpine to 3.15 and ca-certs (old version doesn't exist anymore)
- Added optional MASQUERADE parameter for tun0 to use container as a router to direct all traffic through the VPN